### PR TITLE
Support non-two character uppercase cluster names

### DIFF
--- a/jobhopper/jobhopper.py
+++ b/jobhopper/jobhopper.py
@@ -18,11 +18,11 @@ from twitter.common.zookeeper.serverset import serverset
 
 JOB_RE = r"""
          (?xi) ^
-         (?:(?:(?:(?P<instance>    \d+          )\.)?
+         (?:(?:(?:(?:(?P<instance> \d+          )\.)?
                   (?P<job>         \w[\w.-]*    )\.)?
                (?:(?P<environment> [\w-]+       )\.))?
-                  (?P<role>        [\w-]+       )\.
-                  (?P<cluster>     [A-Z]{2}     )
+                  (?P<role>        [\w-]+       )\.)?
+                  (?P<cluster>     [\w-]+       )
          \.%(subdomain)s
          (?:\.%(domainname)s)?\.?$
          """

--- a/tests/test_jobhopper.py
+++ b/tests/test_jobhopper.py
@@ -20,21 +20,23 @@ class RegexTests(unittest.TestCase):
         self.assertSequenceEqual(match.groups(), expected)
 
     def testTheFancyRegex(self):
-        self.checkmatch('0.job.env.role.xx.aurora.example.com',
-                        ('0', 'job', 'env', 'role', 'xx'))
-        self.checkmatch('job.env.role.xx.aurora.example.com.',
-                        (None, 'job', 'env', 'role', 'xx'))
-        self.checkmatch('job.env.role.xx.aurora',
-                        (None, 'job', 'env', 'role', 'xx'))
-        self.checkmatch('job.env.role.xx.aurora.',
-                        (None, 'job', 'env', 'role', 'xx'))
-        self.checkmatch('role.xx.aurora',
-                        (None, None, None, 'role', 'xx'))
+        self.checkmatch('0.job.env.role.us-east-1.aurora.example.com',
+                        ('0', 'job', 'env', 'role', 'us-east-1'))
+        self.checkmatch('job.env.role.us-west-2.aurora.example.com.',
+                        (None, 'job', 'env', 'role', 'us-west-2'))
+        self.checkmatch('job.env.role.ap-northeast-1.aurora',
+                        (None, 'job', 'env', 'role', 'ap-northeast-1'))
+        self.checkmatch('job.env.role.ap-northeast-2.aurora.',
+                        (None, 'job', 'env', 'role', 'ap-northeast-2'))
+        self.checkmatch('east1.aurora',
+                        (None, None, None, None, 'east1'))
+        self.checkmatch('role.testcluster.aurora',
+                        (None, None, None, 'role', 'testcluster'))
         self.checkmatch('env.role.XX.aurora.',
                         (None, None, 'env', 'role', 'XX'))
         self.checkmatch(
-            'job.foo.bar.jobjob.jobfoo.env.role.XX.aurora',
-            (None, 'job.foo.bar.jobjob.jobfoo', 'env', 'role', 'XX'))
+            'job.foo.bar.jobjob.jobfoo.env.role.my-cluster5.aurora',
+            (None, 'job.foo.bar.jobjob.jobfoo', 'env', 'role', 'my-cluster5'))
         self.checkmatch(
             '123.j-o-b001.foo.bar.jobjob.jobfoo.919.env.role.XX.aurora',
             ('123', 'j-o-b001.foo.bar.jobjob.jobfoo.919', 'env', 'role', 'XX'))


### PR DESCRIPTION
The regex in `jobhopper.py` didn't support any cluster named anything but two characters in all uppercase. This was contradictory to the documentation and was a bit confusing at first. It took me about 10 minutes to track this down with pdb and realize where the issue was.

Fixed the code and updated the tests.
